### PR TITLE
Exclude CLR types of FOR XML Geometry and Geography

### DIFF
--- a/ServiceBrokerListener/ServiceBrokerListener.Domain/SqlDependencyEx.cs
+++ b/ServiceBrokerListener/ServiceBrokerListener.Domain/SqlDependencyEx.cs
@@ -141,7 +141,7 @@ namespace ServiceBrokerListener.Domain
                             
                             SET @select = STUFF((SELECT '','' + ''['' + COLUMN_NAME + '']''
 						                         FROM INFORMATION_SCHEMA.COLUMNS
-						                         WHERE DATA_TYPE NOT IN  (''text'',''ntext'',''image'') AND TABLE_NAME = ''{5}'' AND TABLE_CATALOG = ''{0}''
+						                         WHERE DATA_TYPE NOT IN  (''text'',''ntext'',''image'',''geometry'',''geography'') AND TABLE_NAME = ''{5}'' AND TABLE_CATALOG = ''{0}''
 						                         FOR XML PATH ('''')
 						                         ), 1, 1, '''')
                             SET @sqlInserted = 


### PR DESCRIPTION
Geometry and Geography datatypes are CLR types and do not serialize with the FOR XML query adding them to the exclusion path when calling FOR XML for output