### PR TITLE
Allows uninstall procedure to continue if the service doesn't exist

### DIFF
--- a/ServiceBrokerListener/ServiceBrokerListener.Domain/SqlDependencyEx.cs
+++ b/ServiceBrokerListener/ServiceBrokerListener.Domain/SqlDependencyEx.cs
@@ -257,7 +257,8 @@ namespace ServiceBrokerListener.Domain
                 DEALLOCATE Conv;
 
                 -- Droping service and queue.
-                DROP SERVICE [{1}];
+                IF @serviceId >= 0
+                    DROP SERVICE [{1}];
                 IF OBJECT_ID ('{2}.{0}', 'SQ') IS NOT NULL
 	                DROP QUEUE {2}.[{0}];
             ";

--- a/ServiceBrokerListener/ServiceBrokerListener.Domain/SqlDependencyEx.cs
+++ b/ServiceBrokerListener/ServiceBrokerListener.Domain/SqlDependencyEx.cs
@@ -257,7 +257,7 @@ namespace ServiceBrokerListener.Domain
                 DEALLOCATE Conv;
 
                 -- Droping service and queue.
-                IF @serviceId >= 0
+                IF (@serviceId IS NOT NULL)
                     DROP SERVICE [{1}];
                 IF OBJECT_ID ('{2}.{0}', 'SQ') IS NOT NULL
 	                DROP QUEUE {2}.[{0}];


### PR DESCRIPTION
Fixes issue #56 
I came across a case where the uninstall stored proc doesn't complete because the service doesn't exist anymore. I haven't been able to figure out why the service is gone when this happens, but this fix will at least help auto-recover from this problem.